### PR TITLE
Add files via upload

### DIFF
--- a/SOURCE/PGME/ETERNITY/BLAHBLAH.TXT
+++ b/SOURCE/PGME/ETERNITY/BLAHBLAH.TXT
@@ -17,7 +17,6 @@ Known Issues (That I either can not or will not do anything about):
 	Font's turned into TSRs with QFNT2TSR will not function in DosBox.
 	Sounds cannot be heard in VMware.
 	QScroll Smooth scrolling doesn't work in VMware.
-	ATOM screen saver will not work in DosBox fullscreen mode.
 
 To-Do (Sooner or later, maybe):
 	


### PR DESCRIPTION
Deleted the "	ATOM screen saver will not work in DosBox fullscreen mode." line because it works just fine under GNU/Linux :) Also, the encoding is IBM CP 850 to keep the name of the Spanish translation contributor intact at the bottom of the file.